### PR TITLE
Feature/add kerberos monitor

### DIFF
--- a/internal/cli/cmd.go
+++ b/internal/cli/cmd.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/T-Systems-MMS/fw-id-agent/internal/agent"
 	"github.com/T-Systems-MMS/fw-id-agent/internal/api"
@@ -95,10 +96,30 @@ func getStatus() {
 		return
 	}
 
-	fmt.Printf("Trusted Network: %t\n", status.TrustedNetwork)
-	fmt.Printf("Logged In:       %t\n", status.LoggedIn)
+	fmt.Printf("Trusted Network:    %t\n", status.TrustedNetwork)
+	fmt.Printf("Logged In:          %t\n", status.LoggedIn)
 	if verbose {
-		fmt.Printf("Config:          %#v\n", *status.Config)
+		// kerberos info
+		fmt.Printf("Kerberos TGT:\n")
+
+		// kerberos tgt start time
+		tgtStartTime := time.Unix(status.KerberosTGT.StartTime, 0)
+		if tgtStartTime.IsZero() {
+			fmt.Printf("- StartTime:        0\n")
+		} else {
+			fmt.Printf("- TGT Start:        %s\n", tgtStartTime)
+		}
+
+		// kerberos tgt end time
+		tgtEndTime := time.Unix(status.KerberosTGT.EndTime, 0)
+		if tgtEndTime.IsZero() {
+			fmt.Printf("- EndTime:          0\n")
+		} else {
+			fmt.Printf("- EndTime:          %s\n", tgtEndTime)
+		}
+
+		// agent config
+		fmt.Printf("Config:             %#v\n", *status.Config)
 	}
 }
 

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	"github.com/T-Systems-MMS/fw-id-agent/internal/config"
+	krbConfig "github.com/jcmturner/gokrb5/v8/config"
+	"github.com/jcmturner/gokrb5/v8/credentials"
 )
 
 func TestLogin(t *testing.T) {
@@ -15,7 +17,9 @@ func TestLogin(t *testing.T) {
 	defer server.Close()
 
 	config := &config.Config{ServiceURL: server.URL}
-	client := NewClient(config)
+	ccache := &credentials.CCache{}
+	krb5conf := krbConfig.New()
+	client := NewClient(config, ccache, krb5conf)
 	go func() {
 		defer close(client.results)
 		err := client.login()
@@ -38,7 +42,9 @@ func TestLoginNoResult(t *testing.T) {
 	defer server.Close()
 
 	config := &config.Config{ServiceURL: server.URL}
-	client := NewClient(config)
+	ccache := &credentials.CCache{}
+	krb5conf := krbConfig.New()
+	client := NewClient(config, ccache, krb5conf)
 	go func() {
 		defer close(client.results)
 		_ = client.login()
@@ -59,7 +65,9 @@ func TestLoginFailed(t *testing.T) {
 	defer server.Close()
 
 	config := &config.Config{ServiceURL: server.URL}
-	client := NewClient(config)
+	ccache := &credentials.CCache{}
+	krb5conf := krbConfig.New()
+	client := NewClient(config, ccache, krb5conf)
 	go func() {
 		defer close(client.results)
 		err := client.login()
@@ -82,7 +90,9 @@ func TestLogout(t *testing.T) {
 	defer server.Close()
 
 	config := &config.Config{ServiceURL: server.URL}
-	client := NewClient(config)
+	ccache := &credentials.CCache{}
+	krb5conf := krbConfig.New()
+	client := NewClient(config, ccache, krb5conf)
 	go func() {
 		defer close(client.results)
 		_ = client.login()

--- a/internal/krbmon/ccachemon.go
+++ b/internal/krbmon/ccachemon.go
@@ -1,0 +1,202 @@
+package krbmon
+
+import (
+	"fmt"
+	"os"
+	"os/user"
+	"path/filepath"
+	"reflect"
+	"strings"
+
+	"github.com/fsnotify/fsnotify"
+	"github.com/jcmturner/gokrb5/v8/credentials"
+	"github.com/jcmturner/gokrb5/v8/types"
+	log "github.com/sirupsen/logrus"
+)
+
+// CCacheUpdate is a ccache monitor update
+type CCacheUpdate struct {
+	CCache *credentials.CCache
+}
+
+// GetTGT returns the TGT for realm in the ccache
+func (u *CCacheUpdate) GetTGT(realm string) *credentials.Credential {
+	name := types.NewPrincipalName(2, "krbtgt/"+realm)
+	if tgt, ok := u.CCache.GetEntry(name); ok {
+		return tgt
+	}
+	return nil
+}
+
+// CCacheMon is a ccache monitor
+type CCacheMon struct {
+	cCacheDir  string
+	cCacheFile string
+	cCache     *credentials.CCache
+	updates    chan *CCacheUpdate
+	done       chan struct{}
+}
+
+// sendUpdate sends an update over the updates channel
+func (c *CCacheMon) sendUpdate(update *CCacheUpdate) {
+	// send an update or abort if we are shutting down
+	select {
+	case c.updates <- update:
+	case <-c.done:
+	}
+}
+
+// createCredentialCacheEnvVar creates an expected environment variable value
+// for the credential cache based on the current user ID
+func createCredentialCacheEnvVar() string {
+	osUser, err := user.Current()
+	if err != nil {
+		log.WithError(err).
+			Error("Kerberos CCache Monitor could not create credential cache environment variable value")
+		return ""
+	}
+	return fmt.Sprintf("FILE:/tmp/krb5cc_%s", osUser.Uid)
+}
+
+// getCredentialsCacheFilename returns the ccache file name
+func getCredentialCacheFilename() (string, error) {
+	envVar := os.Getenv("KRB5CCNAME")
+	if envVar == "" {
+		newEnv := createCredentialCacheEnvVar()
+		log.WithField("new", newEnv).
+			Debug("Kerberos CCache Monitor could not get environment variable KRB5CCNAME, setting it")
+		envVar = newEnv
+	}
+	if !strings.HasPrefix(envVar, "FILE:") {
+		newEnv := createCredentialCacheEnvVar()
+		log.WithFields(log.Fields{
+			"old": envVar,
+			"new": newEnv,
+		}).Error("Kerberos CCache Monitor got invalid environment variable KRB5CCNAME, resetting it")
+		envVar = newEnv
+	}
+	if envVar == "" {
+		// environment variable still invalid
+		return "", fmt.Errorf("environment variable KRB5CCNAME is not set")
+	}
+	return strings.TrimPrefix(envVar, "FILE:"), nil
+}
+
+// isCCacheFileEvent checks if event is a ccache file event
+func (c *CCacheMon) isCCacheFileEvent(event fsnotify.Event) bool {
+	if event.Name == c.cCacheFile {
+		return true
+	}
+	return false
+}
+
+// handleCCacheFileEvent handles a ccache file event
+func (c *CCacheMon) handleCCacheFileEvent() {
+	// load ccache
+	cCache, err := credentials.LoadCCache(c.cCacheFile)
+	if err != nil {
+		log.WithError(err).Error("Kerberos CCache Monitor could not load credential cache")
+		return
+	}
+
+	// check if ccache changed
+	if reflect.DeepEqual(cCache, c.cCache) {
+		return
+	}
+
+	// ccache changed, send update
+	c.cCache = cCache
+	c.sendUpdate(&CCacheUpdate{CCache: c.cCache})
+}
+
+// start starts the ccache monitor
+func (c *CCacheMon) start() {
+	defer close(c.updates)
+
+	// get ccache file
+	cCacheFile, err := getCredentialCacheFilename()
+	if err != nil {
+		log.WithError(err).Fatal("Kerberos CCache Monitor could not get CCache file")
+	}
+	c.cCacheFile = cCacheFile
+
+	// get directory of ccache file
+	c.cCacheDir = filepath.Dir(cCacheFile)
+	if c.cCacheDir == "" {
+		log.Fatal("Kerberos CCache Monitor could not get CCache dir")
+	}
+
+	// create watcher
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		log.WithError(err).Fatal("Kerberos CCache Monitor file watcher error")
+	}
+	defer func() {
+		if err := watcher.Close(); err != nil {
+			log.WithError(err).Error("Kerberos CCache Monitor file watcher close error")
+		}
+	}()
+
+	// add ccache folder to watcher
+	if err := watcher.Add(c.cCacheDir); err != nil {
+		log.WithError(err).Debug("Kerberos CCache Monitor add CCache error")
+		return
+	}
+
+	// handle initial ccache file
+	c.handleCCacheFileEvent()
+
+	// watch ccache file
+	for {
+		select {
+		case event, ok := <-watcher.Events:
+			if !ok {
+				log.Error("Kerberos CCache Monitor got unexpected close of events channel")
+				return
+			}
+			if c.isCCacheFileEvent(event) {
+				log.WithFields(log.Fields{
+					"name": event.Name,
+					"op":   event.Op,
+				}).Debug("Kerberos CCache Monitor handling file event")
+				c.handleCCacheFileEvent()
+			}
+
+		case err, ok := <-watcher.Errors:
+			if !ok {
+				log.Error("Kerberos CCache Monitor got unexpected close of errors channel")
+				return
+			}
+			log.WithError(err).Error("Kerberos CCache Monitor watcher error event")
+
+		case <-c.done:
+			return
+		}
+	}
+}
+
+// Start starts the ccache monitor
+func (c *CCacheMon) Start() {
+	go c.start()
+}
+
+// Stop stops the ccache monitor
+func (c *CCacheMon) Stop() {
+	close(c.done)
+	for range c.updates {
+		// wait for channel shutdown
+	}
+}
+
+// Updates returns the channel for ccache updates
+func (c *CCacheMon) Updates() chan *CCacheUpdate {
+	return c.updates
+}
+
+// NewCCacheMon returns a new ccache monitor
+func NewCCacheMon() *CCacheMon {
+	return &CCacheMon{
+		updates: make(chan *CCacheUpdate),
+		done:    make(chan struct{}),
+	}
+}

--- a/internal/krbmon/ccachemon_test.go
+++ b/internal/krbmon/ccachemon_test.go
@@ -1,0 +1,10 @@
+package krbmon
+
+import "testing"
+
+// TestCCacheStartStop tests starting and stopping of CCacheMon
+func TestCCacheMonStartStop(t *testing.T) {
+	cm := NewCCacheMon()
+	cm.Start()
+	cm.Stop()
+}

--- a/internal/krbmon/confmon.go
+++ b/internal/krbmon/confmon.go
@@ -1,0 +1,151 @@
+package krbmon
+
+import (
+	"path/filepath"
+	"reflect"
+
+	"github.com/fsnotify/fsnotify"
+	"github.com/jcmturner/gokrb5/v8/config"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	// krb5conf is the file path of the krb5.conf file
+	krb5conf = "/etc/krb5.conf"
+)
+
+// ConfUpdate is a krb5.conf monitor update
+type ConfUpdate struct {
+	Config *config.Config
+}
+
+// ConfMon is a krb5.conf monitor
+type ConfMon struct {
+	confDir  string
+	confFile string
+	config   *config.Config
+	updates  chan *ConfUpdate
+	done     chan struct{}
+}
+
+// sendUpdate sends an update over the updates channel
+func (c *ConfMon) sendUpdate(update *ConfUpdate) {
+	// send an update or abort if we are shutting down
+	select {
+	case c.updates <- update:
+	case <-c.done:
+	}
+}
+
+// isConfigFileEvent checks if event is a config file event
+func (c *ConfMon) isConfigFileEvent(event fsnotify.Event) bool {
+	if event.Name == c.confFile {
+		return true
+	}
+	return false
+}
+
+// handleConfigFileEvent handles a config file event
+func (c *ConfMon) handleConfigFileEvent() {
+	// load config file
+	cfg, err := config.Load(krb5conf)
+	if err != nil {
+		log.WithError(err).
+			Error("Kerberos Config Monitor could not load config")
+		return
+	}
+
+	// check if config changed
+	if reflect.DeepEqual(cfg, c.config) {
+		return
+	}
+
+	// config changed, send update
+	c.config = cfg
+	c.sendUpdate(&ConfUpdate{Config: c.config})
+}
+
+// start starts the config monitor
+func (c *ConfMon) start() {
+	defer close(c.updates)
+
+	// get directory of ccache file
+	c.confDir = filepath.Dir(krb5conf)
+	if c.confDir == "" {
+		log.Fatal("Kerberos Config Monitor could not get config dir")
+	}
+
+	// create watcher
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		log.WithError(err).Fatal("Kerberos Config Monitor file watcher error")
+	}
+	defer func() {
+		if err := watcher.Close(); err != nil {
+			log.WithError(err).Error("Kerberos Config Monitor file watcher close error")
+		}
+	}()
+
+	// add config folder to watcher
+	if err := watcher.Add(c.confDir); err != nil {
+		log.WithError(err).Debug("Kerberos Config Monitor add CCache error")
+		return
+	}
+
+	// handle initial config file
+	c.handleConfigFileEvent()
+
+	// watch config file
+	for {
+		select {
+		case event, ok := <-watcher.Events:
+			if !ok {
+				log.Error("Kerberos Config Monitor got unexpected close of events channel")
+				return
+			}
+			if c.isConfigFileEvent(event) {
+				log.WithFields(log.Fields{
+					"name": event.Name,
+					"op":   event.Op,
+				}).Debug("Kerberos Config Monitor handling file event")
+				c.handleConfigFileEvent()
+			}
+
+		case err, ok := <-watcher.Errors:
+			if !ok {
+				log.Error("Kerberos Config Monitor got unexpected close of errors channel")
+				return
+			}
+			log.WithError(err).Error("Kerberos Config Monitor watcher error event")
+
+		case <-c.done:
+			return
+		}
+	}
+}
+
+// Start starts the config monitor
+func (c *ConfMon) Start() {
+	go c.start()
+}
+
+// Stop stops the config monitor
+func (c *ConfMon) Stop() {
+	close(c.done)
+	for range c.updates {
+		// wait for channel shutdown
+	}
+}
+
+// Updates returns the channel for config updates
+func (c *ConfMon) Updates() chan *ConfUpdate {
+	return c.updates
+}
+
+// NewConfMon returns a new krb5.conf monitor
+func NewConfMon() *ConfMon {
+	return &ConfMon{
+		updates: make(chan *ConfUpdate),
+		done:    make(chan struct{}),
+	}
+}

--- a/internal/krbmon/confmon_test.go
+++ b/internal/krbmon/confmon_test.go
@@ -1,0 +1,10 @@
+package krbmon
+
+import "testing"
+
+// TestConfMonStartStop tests starting and stopping of ConfMon
+func TestConfMonStartStop(t *testing.T) {
+	cm := NewConfMon()
+	cm.Start()
+	cm.Stop()
+}

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -6,11 +6,18 @@ import (
 	"github.com/T-Systems-MMS/fw-id-agent/internal/config"
 )
 
+// KerberosTicket is kerberos ticket info in the agent status
+type KerberosTicket struct {
+	StartTime int64
+	EndTime   int64
+}
+
 // Status is the agent status
 type Status struct {
 	TrustedNetwork bool
 	LoggedIn       bool
 	Config         *config.Config
+	KerberosTGT    KerberosTicket
 }
 
 // JSON returns the Status as JSON


### PR DESCRIPTION
- Add monitoring of Kerberos credentials cache
- Add monitoring of Kerberos config file
- Add Kerberos TGT start and end times to agent status
- Only login on firewall service when connected to a trusted network and Kerberos credentials and config are available