### PR TITLE
Add login and logout timeout to Config

### DIFF
--- a/configs/config.json
+++ b/configs/config.json
@@ -2,7 +2,8 @@
 	"ServiceURL":"https://myservice.mycompany.com:443",
 	"Realm": "MYKERBEROSREALM.COM",
 	"KeepAlive": 5,
-	"Timeout": 30,
+	"LoginTimeout": 15,
+	"LogoutTimeout": 5,
 	"RetryTimer": 15,
 	"TND":{
 		"HTTPSServers":[

--- a/internal/agent/cmd.go
+++ b/internal/agent/cmd.go
@@ -26,7 +26,8 @@ const (
 	argServiceURL    = "serviceurl"
 	argRealm         = "realm"
 	argKeepAlive     = "keepalive"
-	argTimeout       = "timeout"
+	argLoginTimeout  = "logintimeout"
+	argLogoutTimeout = "logouttimeout"
 	argRetryTimer    = "retrytimer"
 	argTNDServers    = "tndservers"
 	argVerbose       = "verbose"
@@ -74,7 +75,8 @@ func Run() {
 	serviceURL := flag.String(argServiceURL, "", "Set service URL")
 	realm := flag.String(argRealm, "", "Set kerberos realm")
 	keepAlive := flag.Int(argKeepAlive, defaults.KeepAlive, "Set default client keep-alive in `minutes`")
-	timeout := flag.Int(argTimeout, defaults.Timeout, "Set client request timeout in `seconds`")
+	loginTimeout := flag.Int(argLoginTimeout, defaults.LoginTimeout, "Set client login request timeout in `seconds`")
+	logoutTimeout := flag.Int(argLogoutTimeout, defaults.LogoutTimeout, "Set client logout request timeout in `seconds`")
 	retryTimer := flag.Int(argRetryTimer, defaults.RetryTimer, "Set client login retry timer in case of errors in `seconds`")
 	tndServers := flag.String(argTNDServers, "", "Set comma-separated `list` of TND server url:hash pairs")
 	verbose := flag.Bool(argVerbose, defaults.Verbose, "Set verbose output")
@@ -109,8 +111,11 @@ func Run() {
 	if flagIsSet(argKeepAlive) {
 		cfg.KeepAlive = *keepAlive
 	}
-	if flagIsSet(argTimeout) {
-		cfg.Timeout = *timeout
+	if flagIsSet(argLoginTimeout) {
+		cfg.LoginTimeout = *loginTimeout
+	}
+	if flagIsSet(argLogoutTimeout) {
+		cfg.LogoutTimeout = *logoutTimeout
 	}
 	if flagIsSet(argRetryTimer) {
 		cfg.RetryTimer = *retryTimer

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -48,8 +48,10 @@ type Config struct {
 	Realm string
 	// KeepAlive is the default client keep-alive time in minutes
 	KeepAlive int
-	// Timeout is the client's timeout for requests to the service in seconds
-	Timeout int
+	// LoginTimeout is the client's timeout for login requests to the service in seconds
+	LoginTimeout int
+	// LogoutTimeout is the client's timeout for logout requests to the service in seconds
+	LogoutTimeout int
 	// RetryTimer is the client's login retry timer in case of errors in seconds
 	RetryTimer int
 	// TND is the client's trusted network detection configuration
@@ -69,9 +71,14 @@ func (c *Config) GetKeepAlive() time.Duration {
 	return time.Duration(c.KeepAlive) * time.Minute
 }
 
-// GetTimeout returns the client timeout as Duration
-func (c *Config) GetTimeout() time.Duration {
-	return time.Duration(c.Timeout) * time.Second
+// GetLoginTimeout returns the client login timeout as Duration
+func (c *Config) GetLoginTimeout() time.Duration {
+	return time.Duration(c.LoginTimeout) * time.Second
+}
+
+// GetLogoutTimeout returns the client logout timeout as Duration
+func (c *Config) GetLogoutTimeout() time.Duration {
+	return time.Duration(c.LogoutTimeout) * time.Second
 }
 
 // GetRetryTimer returns the client retry timer as Duration
@@ -90,7 +97,8 @@ func (c *Config) Valid() bool {
 		c.ServiceURL == "" ||
 		c.Realm == "" ||
 		c.KeepAlive < 0 ||
-		c.Timeout < 0 ||
+		c.LoginTimeout < 0 ||
+		c.LogoutTimeout < 0 ||
 		c.RetryTimer < 0 ||
 		!c.TND.Valid() ||
 		c.MinUserID < 0 ||
@@ -114,7 +122,8 @@ func (c *Config) JSON() ([]byte, error) {
 func Default() *Config {
 	return &Config{
 		KeepAlive:     5,
-		Timeout:       30,
+		LoginTimeout:  15,
+		LogoutTimeout: 5,
 		RetryTimer:    15,
 		MinUserID:     1000,
 		StartDelay:    20,

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -19,11 +19,21 @@ func TestConfigGetKeepAlive(t *testing.T) {
 	}
 }
 
-// TestConfigGetTimeout tests GetTimeout of Config
-func TestConfigGetTimeout(t *testing.T) {
-	config := &Config{Timeout: 30}
-	want := 30 * time.Second
-	got := config.GetTimeout()
+// TestConfigGetLoginTimeout tests GetLoginTimeout of Config
+func TestConfigGetLoginTimeout(t *testing.T) {
+	config := &Config{LoginTimeout: 15}
+	want := 15 * time.Second
+	got := config.GetLoginTimeout()
+	if got != want {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+// TestConfigGetLogoutTimeout tests GetLoginTimeout of Config
+func TestConfigGetLogoutTimeout(t *testing.T) {
+	config := &Config{LogoutTimeout: 5}
+	want := 5 * time.Second
+	got := config.GetLogoutTimeout()
 	if got != want {
 		t.Errorf("got %v, want %v", got, want)
 	}
@@ -83,7 +93,8 @@ func TestConfigValid(t *testing.T) {
 func TestDefault(t *testing.T) {
 	want := &Config{
 		KeepAlive:     5,
-		Timeout:       30,
+		LoginTimeout:  15,
+		LogoutTimeout: 5,
 		RetryTimer:    15,
 		MinUserID:     1000,
 		StartDelay:    20,
@@ -125,7 +136,8 @@ func TestLoad(t *testing.T) {
         "ServiceURL":"https://myservice.mycompany.com:443",
         "Realm": "MYKERBEROSREALM.COM",
 	"KeepAlive": 5,
-	"Timeout": 30,
+	"LoginTimeout": 15,
+	"LogoutTimeout": 5,
 	"RetryTimer": 15,
         "TND":{
                 "HTTPSServers":[
@@ -181,11 +193,12 @@ func TestLoad(t *testing.T) {
 		}
 
 		want := &Config{
-			ServiceURL: "https://myservice.mycompany.com:443",
-			Realm:      "MYKERBEROSREALM.COM",
-			KeepAlive:  5,
-			Timeout:    30,
-			RetryTimer: 15,
+			ServiceURL:    "https://myservice.mycompany.com:443",
+			Realm:         "MYKERBEROSREALM.COM",
+			KeepAlive:     5,
+			LoginTimeout:  15,
+			LogoutTimeout: 5,
+			RetryTimer:    15,
 			TND: TNDConfig{
 				[]TNDHTTPSConfig{
 					{


### PR DESCRIPTION
Remove the generic request timeout from Config and add individual timeouts for login and logout requests.